### PR TITLE
Enables akka logs on startup and shutdown

### DIFF
--- a/src/main/g8/play/src/main/resources/akka.conf
+++ b/src/main/g8/play/src/main/resources/akka.conf
@@ -6,7 +6,9 @@ akka {
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   # This is intentionally set to DEBUG - tune logging by adding filters to logback.xml file
   loglevel = "DEBUG"
-  stdout-loglevel = "OFF"
+  # Akka logs ONLY to stdout when the actor system is starting up and shutting down
+  # Setting this to OFF will silence those logs, but we will loose the visibility.
+  stdout-loglevel = "DEBUG"
   jvm-exit-on-fatal-error = on
 
   actor {


### PR DESCRIPTION
According to https://doc.akka.io/docs/akka/current/logging.html#turn-off-logging
> The stdout-loglevel is only in effect during system startup and shutdown, and setting it to OFF as well, ensures that nothing gets logged during system startup or shutdown.

But this also means that we loose those valuable logs!